### PR TITLE
Add shift pass-over web app backend and UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+backend/node_modules
+backend/data
+backend/uploads

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# rmemeber
-remember
+# Motherlode Pass-Over App
+
+Simple shift pass-over web application using Node.js, Express, lowdb and a single-page HTML frontend.
+
+## Development
+
+```sh
+cd backend
+npm install
+node server.js
+```
+
+Default admin login: `admin@motherlode.local` / `ChangeMe123!`

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,20 +1,38 @@
 import { Low } from 'lowdb'
 import { JSONFile } from 'lowdb/node'
-import { join } from 'path'
-import { existsSync, mkdirSync } from 'fs'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const dataDir = process.env.DATA_DIR || process.cwd()
-if (!existsSync(dataDir)) {
-  mkdirSync(dataDir, { recursive: true })
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// Where to store the DB file (override via env if you want)
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data')
+if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true })
+
+const file = path.join(DATA_DIR, 'motherlode.json')
+
+// *** IMPORTANT: provide default data ***
+const defaultData = {
+  users: [],
+  sessions: [],
+  entries: []
 }
-const file = join(dataDir, 'motherlode.json')
 
 const adapter = new JSONFile(file)
-export const db = new Low(adapter)
-await db.read()
-if (!db.data) {
-  db.data = { users: [], entries: [] }
-  await db.write()
+export const db = new Low(adapter, defaultData)
+
+export async function initDb() {
+  try {
+    await db.read()
+    // If file was empty or missing, ensure defaults are present
+    db.data ||= defaultData
+    await db.write()
+  } catch (err) {
+    console.error('Failed to init DB, resetting with defaults:', err)
+    db.data = defaultData
+    await db.write()
+  }
 }
 
-export default db

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,20 @@
+import { Low } from 'lowdb'
+import { JSONFile } from 'lowdb/node'
+import { join } from 'path'
+import { existsSync, mkdirSync } from 'fs'
+
+const dataDir = process.env.DATA_DIR || process.cwd()
+if (!existsSync(dataDir)) {
+  mkdirSync(dataDir, { recursive: true })
+}
+const file = join(dataDir, 'motherlode.json')
+
+const adapter = new JSONFile(file)
+export const db = new Low(adapter)
+await db.read()
+if (!db.data) {
+  db.data = { users: [], entries: [] }
+  await db.write()
+}
+
+export default db

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "motherlode-passover-backend",
+  "version": "1.0.0",
+  "description": "Shift Pass-Over Web App backend",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "lowdb": "^6.0.1",
+    "multer": "^2.0.0-rc.1"
+  }
+}

--- a/backend/public/app.js
+++ b/backend/public/app.js
@@ -1,0 +1,66 @@
+function app() {
+  return {
+    user: null,
+    email: '',
+    password: '',
+    oldPassword: '',
+    newPassword: '',
+    showPw: false,
+    entries: [],
+    filterDate: '',
+    entry: { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '' },
+    async init() {
+      const res = await fetch('/api/auth/me', { credentials: 'include' }).then(r => r.ok ? r.json() : null)
+      if (res && res.user) { this.user = res.user; this.loadEntries() }
+    },
+    async login() {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email: this.email, password: this.password })
+      })
+      if (res.ok) { this.user = (await res.json()).user; this.loadEntries() }
+    },
+    async logout() {
+      await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+      this.user = null
+    },
+    async changePassword() {
+      await fetch('/api/users/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ oldPassword: this.oldPassword, newPassword: this.newPassword })
+      })
+      this.showPw = false
+      this.oldPassword = this.newPassword = ''
+    },
+    async createEntry() {
+      const files = this.$refs.files.files
+      let attachments = []
+      if (files.length) {
+        const fd = new FormData()
+        for (const f of files) fd.append('files', f)
+        const up = await fetch('/api/upload', { method: 'POST', body: fd, credentials: 'include' })
+        if (up.ok) attachments = (await up.json()).files
+      }
+      const payload = { ...this.entry, attachments }
+      await fetch('/api/entries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload)
+      })
+      this.entry = { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '' }
+      this.$refs.files.value = null
+      this.loadEntries()
+    },
+    async loadEntries() {
+      const params = new URLSearchParams()
+      if (this.filterDate) params.append('date', this.filterDate)
+      const res = await fetch('/api/entries?' + params.toString(), { credentials: 'include' })
+      if (res.ok) this.entries = await res.json()
+    }
+  }
+}

--- a/backend/public/app.js
+++ b/backend/public/app.js
@@ -5,13 +5,13 @@ function app() {
     password: '',
     oldPassword: '',
     newPassword: '',
-    showPw: false,
+    view: 'new',
     entries: [],
     filterDate: '',
     entry: { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '' },
     async init() {
       const res = await fetch('/api/auth/me', { credentials: 'include' }).then(r => r.ok ? r.json() : null)
-      if (res && res.user) { this.user = res.user; this.loadEntries() }
+      if (res && res.user) { this.user = res.user; this.view = 'new'; this.loadEntries() }
     },
     async login() {
       const res = await fetch('/api/auth/login', {
@@ -20,11 +20,12 @@ function app() {
         credentials: 'include',
         body: JSON.stringify({ email: this.email, password: this.password })
       })
-      if (res.ok) { this.user = (await res.json()).user; this.loadEntries() }
+      if (res.ok) { this.user = (await res.json()).user; this.view = 'new'; this.loadEntries() }
     },
     async logout() {
       await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
       this.user = null
+      this.view = 'new'
     },
     async changePassword() {
       await fetch('/api/users/change-password', {
@@ -33,7 +34,6 @@ function app() {
         credentials: 'include',
         body: JSON.stringify({ oldPassword: this.oldPassword, newPassword: this.newPassword })
       })
-      this.showPw = false
       this.oldPassword = this.newPassword = ''
     },
     async createEntry() {
@@ -61,6 +61,10 @@ function app() {
       if (this.filterDate) params.append('date', this.filterDate)
       const res = await fetch('/api/entries?' + params.toString(), { credentials: 'include' })
       if (res.ok) this.entries = await res.json()
+    },
+    setView(v) {
+      this.view = v
+      if (v === 'list') this.loadEntries()
     }
   }
 }

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -7,69 +7,83 @@
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
   <title>Shift Pass-Over</title>
 </head>
-<body class="p-4">
-<div x-show="!user">
-  <h1 class="text-xl mb-2">Login</h1>
-  <form @submit.prevent="login">
-    <input x-model="email" type="email" placeholder="Email" class="border p-1" required />
-    <input x-model="password" type="password" placeholder="Password" class="border p-1" required />
-    <button class="bg-blue-500 text-white px-2">Login</button>
-  </form>
-</div>
-
-<div x-show="user">
-  <div class="mb-4 flex justify-between">
-    <h1 class="text-xl">Welcome <span x-text="user.name"></span></h1>
-    <button @click="logout" class="text-red-500">Logout</button>
+<body class="bg-gray-100 p-4">
+<div class="max-w-3xl mx-auto" x-cloak>
+  <!-- Login -->
+  <div x-show="!user" class="bg-white shadow rounded p-6 space-y-4">
+    <h1 class="text-2xl font-bold text-center">Motherlode Pass-Over</h1>
+    <form class="space-y-3" @submit.prevent="login">
+      <input x-model="email" type="email" placeholder="Email" class="border p-2 w-full" required />
+      <input x-model="password" type="password" placeholder="Password" class="border p-2 w-full" required />
+      <button class="w-full bg-blue-600 text-white py-2 rounded">Login</button>
+    </form>
   </div>
 
-  <h2 class="text-lg">New Entry</h2>
-  <form @submit.prevent="createEntry" class="space-y-2">
-    <div>
-      <label>Date <input type="date" x-model="entry.date" required class="border" /></label>
-      <label>Shift
-        <select x-model="entry.shift" class="border" required>
-          <option value="AM">AM</option>
-          <option value="PM">PM</option>
-        </select>
-      </label>
-      <label>Line
-        <select x-model="entry.line" class="border" required>
-          <option value="1">1</option>
-          <option value="2">2</option>
-        </select>
-      </label>
-    </div>
-    <div>
-      <textarea x-model="entry.completedTasks" placeholder="Completed tasks" class="border w-full"></textarea>
-    </div>
-    <div>
-      <textarea x-model="entry.issues" placeholder="Issues" class="border w-full"></textarea>
-    </div>
-    <div>
-      <textarea x-model="entry.nextActions" placeholder="Next actions" class="border w-full"></textarea>
-    </div>
-    <div>
-      <label>Downtime <input type="number" x-model="entry.downtime" class="border w-20" /></label>
-      <label>Shortages <input type="text" x-model="entry.shortages" class="border" /></label>
-      <label>Sanitation <input type="text" x-model="entry.sanitation" class="border" /></label>
-    </div>
-    <div>
-      <input type="file" multiple x-ref="files" />
-    </div>
-    <button class="bg-green-500 text-white px-2">Save</button>
-  </form>
-
-  <h2 class="text-lg mt-6">Recent Entries</h2>
-  <div>
-    <template x-for="e in entries" :key="e.id">
-      <div class="border p-2 my-2">
-        <div><b x-text="e.date"></b> - <span x-text="e.shift"></span> - Line <span x-text="e.line"></span></div>
-        <div x-text="e.completedTasks"></div>
-        <div x-text="e.issues"></div>
-        <div x-text="e.nextActions"></div>
+  <!-- App -->
+  <div x-show="user" class="space-y-6">
+    <div class="bg-white shadow rounded p-4 flex justify-between items-center">
+      <h1 class="text-xl font-semibold">Welcome <span x-text="user.name"></span></h1>
+      <div class="space-x-2">
+        <button @click="showPw = !showPw" class="text-sm text-blue-600">Change Password</button>
+        <button @click="logout" class="text-sm text-red-600">Logout</button>
       </div>
-    </template>
+    </div>
+
+    <div x-show="showPw" class="bg-white shadow rounded p-4">
+      <form @submit.prevent="changePassword" class="space-y-2">
+        <input type="password" placeholder="Old password" x-model="oldPassword" class="border p-2 w-full" required />
+        <input type="password" placeholder="New password" x-model="newPassword" class="border p-2 w-full" required />
+        <button class="bg-blue-600 text-white px-3 py-1 rounded">Update</button>
+      </form>
+    </div>
+
+    <div class="bg-white shadow rounded p-4">
+      <h2 class="text-lg font-semibold mb-2">New Entry</h2>
+      <form @submit.prevent="createEntry" class="space-y-3">
+        <div class="flex flex-wrap gap-2">
+          <label>Date <input type="date" x-model="entry.date" required class="border p-1"></label>
+          <label>Shift
+            <select x-model="entry.shift" class="border p-1" required>
+              <option value="AM">AM</option>
+              <option value="PM">PM</option>
+            </select>
+          </label>
+          <label>Line
+            <select x-model="entry.line" class="border p-1" required>
+              <option value="1">1</option>
+              <option value="2">2</option>
+            </select>
+          </label>
+        </div>
+        <textarea x-model="entry.completedTasks" placeholder="Completed tasks" class="border w-full p-1"></textarea>
+        <textarea x-model="entry.issues" placeholder="Issues" class="border w-full p-1"></textarea>
+        <textarea x-model="entry.nextActions" placeholder="Next actions" class="border w-full p-1"></textarea>
+        <div>
+          <input type="file" multiple x-ref="files" />
+        </div>
+        <button class="bg-green-600 text-white px-3 py-1 rounded">Save</button>
+      </form>
+    </div>
+
+    <div class="bg-white shadow rounded p-4">
+      <div class="flex justify-between items-center mb-2">
+        <h2 class="text-lg font-semibold">Entries</h2>
+        <input type="date" x-model="filterDate" @change="loadEntries" class="border p-1" />
+      </div>
+      <div>
+        <template x-for="e in entries" :key="e.id">
+          <div class="border p-2 my-2 rounded bg-gray-50">
+            <div class="flex justify-between">
+              <div><b x-text="e.date"></b> - <span x-text="e.shift"></span> - Line <span x-text="e.line"></span></div>
+              <a :href="`/api/entries/export?date=${e.date}&line=${e.line}`" class="text-sm text-blue-600">Export</a>
+            </div>
+            <div class="mt-1" x-text="e.completedTasks"></div>
+            <div class="mt-1" x-text="e.issues"></div>
+            <div class="mt-1" x-text="e.nextActions"></div>
+          </div>
+        </template>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -79,18 +93,38 @@ function app() {
     user: null,
     email: '',
     password: '',
+    oldPassword: '',
+    newPassword: '',
+    showPw: false,
     entries: [],
-    entry: { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '', downtime: 0, shortages: '', sanitation: '' },
+    filterDate: '',
+    entry: { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '' },
     async init() {
-      const res = await fetch('/api/auth/me').then(r => r.ok ? r.json() : null)
+      const res = await fetch('/api/auth/me', { credentials: 'include' }).then(r => r.ok ? r.json() : null)
       if (res && res.user) { this.user = res.user; this.loadEntries() }
     },
     async login() {
-      const res = await fetch('/api/auth/login', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email: this.email, password: this.password }) })
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ email: this.email, password: this.password })
+      })
       if (res.ok) { this.user = (await res.json()).user; this.loadEntries() }
     },
     async logout() {
-      await fetch('/api/auth/logout', { method: 'POST' }); this.user = null
+      await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+      this.user = null
+    },
+    async changePassword() {
+      await fetch('/api/users/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ oldPassword: this.oldPassword, newPassword: this.newPassword })
+      })
+      this.showPw = false
+      this.oldPassword = this.newPassword = ''
     },
     async createEntry() {
       const files = this.$refs.files.files
@@ -98,17 +132,24 @@ function app() {
       if (files.length) {
         const fd = new FormData()
         for (const f of files) fd.append('files', f)
-        const up = await fetch('/api/upload', { method: 'POST', body: fd })
+        const up = await fetch('/api/upload', { method: 'POST', body: fd, credentials: 'include' })
         if (up.ok) attachments = (await up.json()).files
       }
       const payload = { ...this.entry, attachments }
-      await fetch('/api/entries', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
-      this.entry = { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '', downtime: 0, shortages: '', sanitation: '' }
+      await fetch('/api/entries', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload)
+      })
+      this.entry = { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '' }
       this.$refs.files.value = null
       this.loadEntries()
     },
     async loadEntries() {
-      const res = await fetch('/api/entries')
+      const params = new URLSearchParams()
+      if (this.filterDate) params.append('date', this.filterDate)
+      const res = await fetch('/api/entries?' + params.toString(), { credentials: 'include' })
       if (res.ok) this.entries = await res.json()
     }
   }

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en" x-data="app()" x-init="init()">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <title>Shift Pass-Over</title>
+</head>
+<body class="p-4">
+<div x-show="!user">
+  <h1 class="text-xl mb-2">Login</h1>
+  <form @submit.prevent="login">
+    <input x-model="email" type="email" placeholder="Email" class="border p-1" required />
+    <input x-model="password" type="password" placeholder="Password" class="border p-1" required />
+    <button class="bg-blue-500 text-white px-2">Login</button>
+  </form>
+</div>
+
+<div x-show="user">
+  <div class="mb-4 flex justify-between">
+    <h1 class="text-xl">Welcome <span x-text="user.name"></span></h1>
+    <button @click="logout" class="text-red-500">Logout</button>
+  </div>
+
+  <h2 class="text-lg">New Entry</h2>
+  <form @submit.prevent="createEntry" class="space-y-2">
+    <div>
+      <label>Date <input type="date" x-model="entry.date" required class="border" /></label>
+      <label>Shift
+        <select x-model="entry.shift" class="border" required>
+          <option value="AM">AM</option>
+          <option value="PM">PM</option>
+        </select>
+      </label>
+      <label>Line
+        <select x-model="entry.line" class="border" required>
+          <option value="1">1</option>
+          <option value="2">2</option>
+        </select>
+      </label>
+    </div>
+    <div>
+      <textarea x-model="entry.completedTasks" placeholder="Completed tasks" class="border w-full"></textarea>
+    </div>
+    <div>
+      <textarea x-model="entry.issues" placeholder="Issues" class="border w-full"></textarea>
+    </div>
+    <div>
+      <textarea x-model="entry.nextActions" placeholder="Next actions" class="border w-full"></textarea>
+    </div>
+    <div>
+      <label>Downtime <input type="number" x-model="entry.downtime" class="border w-20" /></label>
+      <label>Shortages <input type="text" x-model="entry.shortages" class="border" /></label>
+      <label>Sanitation <input type="text" x-model="entry.sanitation" class="border" /></label>
+    </div>
+    <div>
+      <input type="file" multiple x-ref="files" />
+    </div>
+    <button class="bg-green-500 text-white px-2">Save</button>
+  </form>
+
+  <h2 class="text-lg mt-6">Recent Entries</h2>
+  <div>
+    <template x-for="e in entries" :key="e.id">
+      <div class="border p-2 my-2">
+        <div><b x-text="e.date"></b> - <span x-text="e.shift"></span> - Line <span x-text="e.line"></span></div>
+        <div x-text="e.completedTasks"></div>
+        <div x-text="e.issues"></div>
+        <div x-text="e.nextActions"></div>
+      </div>
+    </template>
+  </div>
+</div>
+
+<script>
+function app() {
+  return {
+    user: null,
+    email: '',
+    password: '',
+    entries: [],
+    entry: { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '', downtime: 0, shortages: '', sanitation: '' },
+    async init() {
+      const res = await fetch('/api/auth/me').then(r => r.ok ? r.json() : null)
+      if (res && res.user) { this.user = res.user; this.loadEntries() }
+    },
+    async login() {
+      const res = await fetch('/api/auth/login', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email: this.email, password: this.password }) })
+      if (res.ok) { this.user = (await res.json()).user; this.loadEntries() }
+    },
+    async logout() {
+      await fetch('/api/auth/logout', { method: 'POST' }); this.user = null
+    },
+    async createEntry() {
+      const files = this.$refs.files.files
+      let attachments = []
+      if (files.length) {
+        const fd = new FormData()
+        for (const f of files) fd.append('files', f)
+        const up = await fetch('/api/upload', { method: 'POST', body: fd })
+        if (up.ok) attachments = (await up.json()).files
+      }
+      const payload = { ...this.entry, attachments }
+      await fetch('/api/entries', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+      this.entry = { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '', downtime: 0, shortages: '', sanitation: '' }
+      this.$refs.files.value = null
+      this.loadEntries()
+    },
+    async loadEntries() {
+      const res = await fetch('/api/entries')
+      if (res.ok) this.entries = await res.json()
+    }
+  }
+}
+</script>
+</body>
+</html>

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -9,85 +9,95 @@
   <script src="/app.js" defer></script>
   <title>Shift Pass-Over</title>
 </head>
-<body class="p-4">
-<div class="max-w-3xl mx-auto" x-cloak>
-  <!-- Login -->
-  <div x-show="!user" class="card space-y-4">
-    <h1 class="text-2xl font-bold text-center">Motherlode Pass-Over</h1>
-    <form class="space-y-3" @submit.prevent="login">
-      <input x-model="email" type="email" placeholder="Email" class="border p-2 w-full" required />
-      <input x-model="password" type="password" placeholder="Password" class="border p-2 w-full" required />
-      <button class="btn btn-primary w-full">Login</button>
-    </form>
+<body class="min-h-screen">
+  <!-- Login Screen -->
+  <div x-show="!user" x-cloak class="flex items-center justify-center min-h-screen">
+    <div class="card w-full max-w-sm">
+      <h1 class="text-2xl font-bold text-center mb-4">Motherlode Pass-Over</h1>
+      <form class="space-y-3" @submit.prevent="login">
+        <input x-model="email" type="email" placeholder="Email" class="border p-2 w-full" required />
+        <input x-model="password" type="password" placeholder="Password" class="border p-2 w-full" required />
+        <button class="btn btn-primary w-full">Login</button>
+      </form>
+    </div>
   </div>
 
   <!-- App -->
-  <div x-show="user" class="space-y-6">
-    <div class="card flex justify-between items-center">
-      <h1 class="text-xl font-semibold">Welcome <span x-text="user.name"></span></h1>
-      <div class="space-x-2">
-        <button @click="showPw = !showPw" class="link">Change Password</button>
-        <button @click="logout" class="link text-red-600">Logout</button>
-      </div>
-    </div>
-
-    <div x-show="showPw" class="card">
-      <form @submit.prevent="changePassword" class="space-y-2">
-        <input type="password" placeholder="Old password" x-model="oldPassword" class="border p-2 w-full" required />
-        <input type="password" placeholder="New password" x-model="newPassword" class="border p-2 w-full" required />
-        <button class="btn btn-primary">Update</button>
-      </form>
-    </div>
-
-    <div class="card">
-      <h2 class="text-lg font-semibold mb-2">New Entry</h2>
-      <form @submit.prevent="createEntry" class="space-y-3">
-        <div class="flex flex-wrap gap-2">
-          <label>Date <input type="date" x-model="entry.date" required class="border p-1"></label>
-          <label>Shift
-            <select x-model="entry.shift" class="border p-1" required>
-              <option value="AM">AM</option>
-              <option value="PM">PM</option>
-            </select>
-          </label>
-          <label>Line
-            <select x-model="entry.line" class="border p-1" required>
-              <option value="1">1</option>
-              <option value="2">2</option>
-            </select>
-          </label>
-        </div>
-        <textarea x-model="entry.completedTasks" placeholder="Completed tasks" class="border w-full p-1"></textarea>
-        <textarea x-model="entry.issues" placeholder="Issues" class="border w-full p-1"></textarea>
-        <textarea x-model="entry.nextActions" placeholder="Next actions" class="border w-full p-1"></textarea>
-        <div>
-          <input type="file" multiple x-ref="files" />
-        </div>
-        <button class="btn btn-secondary">Save</button>
-      </form>
-    </div>
-
-    <div class="card">
-      <div class="flex justify-between items-center mb-2">
-        <h2 class="text-lg font-semibold">Entries</h2>
-        <input type="date" x-model="filterDate" @change="loadEntries" class="border p-1" />
-      </div>
-      <div>
-        <template x-for="e in entries" :key="e.id">
-          <div class="border p-2 my-2 rounded bg-gray-50">
-            <div class="flex justify-between">
-              <div><b x-text="e.date"></b> - <span x-text="e.shift"></span> - Line <span x-text="e.line"></span></div>
-              <a :href="`/api/entries/export?date=${e.date}&line=${e.line}`" class="link">Export</a>
+  <div x-show="user" x-cloak class="flex flex-col min-h-screen">
+    <header class="header p-4 flex justify-between items-center">
+      <h1 class="text-xl font-semibold">Motherlode Pass-Over</h1>
+      <nav class="space-x-2">
+        <button class="nav-btn" :class="{'nav-active': view==='new'}" @click="setView('new')">New Entry</button>
+        <button class="nav-btn" :class="{'nav-active': view==='list'}" @click="setView('list')">Entries</button>
+        <button class="nav-btn" :class="{'nav-active': view==='account'}" @click="setView('account')">Account</button>
+        <button class="nav-btn" @click="logout">Logout</button>
+      </nav>
+    </header>
+    <main class="p-4 flex-1">
+      <template x-if="view==='new'">
+        <div class="max-w-3xl mx-auto card">
+          <h2 class="text-lg font-semibold mb-2">New Entry</h2>
+          <form @submit.prevent="createEntry" class="space-y-3">
+            <div class="flex flex-wrap gap-2">
+              <label>Date <input type="date" x-model="entry.date" required class="border p-1"></label>
+              <label>Shift
+                <select x-model="entry.shift" class="border p-1" required>
+                  <option value="AM">AM</option>
+                  <option value="PM">PM</option>
+                </select>
+              </label>
+              <label>Line
+                <select x-model="entry.line" class="border p-1" required>
+                  <option value="1">1</option>
+                  <option value="2">2</option>
+                </select>
+              </label>
             </div>
-            <div class="mt-1" x-text="e.completedTasks"></div>
-            <div class="mt-1" x-text="e.issues"></div>
-            <div class="mt-1" x-text="e.nextActions"></div>
+            <textarea x-model="entry.completedTasks" placeholder="Completed tasks" class="border w-full p-1"></textarea>
+            <textarea x-model="entry.issues" placeholder="Issues" class="border w-full p-1"></textarea>
+            <textarea x-model="entry.nextActions" placeholder="Next actions" class="border w-full p-1"></textarea>
+            <div>
+              <input type="file" multiple x-ref="files" />
+            </div>
+            <button class="btn btn-secondary">Save</button>
+          </form>
+        </div>
+      </template>
+
+      <template x-if="view==='list'">
+        <div class="max-w-3xl mx-auto card">
+          <div class="flex justify-between items-center mb-2">
+            <h2 class="text-lg font-semibold">Entries</h2>
+            <input type="date" x-model="filterDate" @change="loadEntries" class="border p-1" />
           </div>
-        </template>
-      </div>
-    </div>
+          <div>
+            <template x-for="e in entries" :key="e.id">
+              <div class="border p-2 my-2 rounded bg-gray-50">
+                <div class="flex justify-between">
+                  <div><b x-text="e.date"></b> - <span x-text="e.shift"></span> - Line <span x-text="e.line"></span></div>
+                  <a :href="`/api/entries/export?date=${e.date}&line=${e.line}`" class="link">Export</a>
+                </div>
+                <div class="mt-1" x-text="e.completedTasks"></div>
+                <div class="mt-1" x-text="e.issues"></div>
+                <div class="mt-1" x-text="e.nextActions"></div>
+              </div>
+            </template>
+          </div>
+        </div>
+      </template>
+
+      <template x-if="view==='account'">
+        <div class="max-w-md mx-auto card">
+          <h2 class="text-lg font-semibold mb-2">Change Password</h2>
+          <form @submit.prevent="changePassword" class="space-y-2">
+            <input type="password" placeholder="Old password" x-model="oldPassword" class="border p-2 w-full" required />
+            <input type="password" placeholder="New password" x-model="newPassword" class="border p-2 w-full" required />
+            <button class="btn btn-primary">Update</button>
+          </form>
+        </div>
+      </template>
+    </main>
   </div>
-</div>
 
 </body>
 </html>

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -5,39 +5,41 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+  <link rel="stylesheet" href="/style.css" />
+  <script src="/app.js" defer></script>
   <title>Shift Pass-Over</title>
 </head>
-<body class="bg-gray-100 p-4">
+<body class="p-4">
 <div class="max-w-3xl mx-auto" x-cloak>
   <!-- Login -->
-  <div x-show="!user" class="bg-white shadow rounded p-6 space-y-4">
+  <div x-show="!user" class="card space-y-4">
     <h1 class="text-2xl font-bold text-center">Motherlode Pass-Over</h1>
     <form class="space-y-3" @submit.prevent="login">
       <input x-model="email" type="email" placeholder="Email" class="border p-2 w-full" required />
       <input x-model="password" type="password" placeholder="Password" class="border p-2 w-full" required />
-      <button class="w-full bg-blue-600 text-white py-2 rounded">Login</button>
+      <button class="btn btn-primary w-full">Login</button>
     </form>
   </div>
 
   <!-- App -->
   <div x-show="user" class="space-y-6">
-    <div class="bg-white shadow rounded p-4 flex justify-between items-center">
+    <div class="card flex justify-between items-center">
       <h1 class="text-xl font-semibold">Welcome <span x-text="user.name"></span></h1>
       <div class="space-x-2">
-        <button @click="showPw = !showPw" class="text-sm text-blue-600">Change Password</button>
-        <button @click="logout" class="text-sm text-red-600">Logout</button>
+        <button @click="showPw = !showPw" class="link">Change Password</button>
+        <button @click="logout" class="link text-red-600">Logout</button>
       </div>
     </div>
 
-    <div x-show="showPw" class="bg-white shadow rounded p-4">
+    <div x-show="showPw" class="card">
       <form @submit.prevent="changePassword" class="space-y-2">
         <input type="password" placeholder="Old password" x-model="oldPassword" class="border p-2 w-full" required />
         <input type="password" placeholder="New password" x-model="newPassword" class="border p-2 w-full" required />
-        <button class="bg-blue-600 text-white px-3 py-1 rounded">Update</button>
+        <button class="btn btn-primary">Update</button>
       </form>
     </div>
 
-    <div class="bg-white shadow rounded p-4">
+    <div class="card">
       <h2 class="text-lg font-semibold mb-2">New Entry</h2>
       <form @submit.prevent="createEntry" class="space-y-3">
         <div class="flex flex-wrap gap-2">
@@ -61,11 +63,11 @@
         <div>
           <input type="file" multiple x-ref="files" />
         </div>
-        <button class="bg-green-600 text-white px-3 py-1 rounded">Save</button>
+        <button class="btn btn-secondary">Save</button>
       </form>
     </div>
 
-    <div class="bg-white shadow rounded p-4">
+    <div class="card">
       <div class="flex justify-between items-center mb-2">
         <h2 class="text-lg font-semibold">Entries</h2>
         <input type="date" x-model="filterDate" @change="loadEntries" class="border p-1" />
@@ -75,7 +77,7 @@
           <div class="border p-2 my-2 rounded bg-gray-50">
             <div class="flex justify-between">
               <div><b x-text="e.date"></b> - <span x-text="e.shift"></span> - Line <span x-text="e.line"></span></div>
-              <a :href="`/api/entries/export?date=${e.date}&line=${e.line}`" class="text-sm text-blue-600">Export</a>
+              <a :href="`/api/entries/export?date=${e.date}&line=${e.line}`" class="link">Export</a>
             </div>
             <div class="mt-1" x-text="e.completedTasks"></div>
             <div class="mt-1" x-text="e.issues"></div>
@@ -87,73 +89,5 @@
   </div>
 </div>
 
-<script>
-function app() {
-  return {
-    user: null,
-    email: '',
-    password: '',
-    oldPassword: '',
-    newPassword: '',
-    showPw: false,
-    entries: [],
-    filterDate: '',
-    entry: { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '' },
-    async init() {
-      const res = await fetch('/api/auth/me', { credentials: 'include' }).then(r => r.ok ? r.json() : null)
-      if (res && res.user) { this.user = res.user; this.loadEntries() }
-    },
-    async login() {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ email: this.email, password: this.password })
-      })
-      if (res.ok) { this.user = (await res.json()).user; this.loadEntries() }
-    },
-    async logout() {
-      await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
-      this.user = null
-    },
-    async changePassword() {
-      await fetch('/api/users/change-password', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ oldPassword: this.oldPassword, newPassword: this.newPassword })
-      })
-      this.showPw = false
-      this.oldPassword = this.newPassword = ''
-    },
-    async createEntry() {
-      const files = this.$refs.files.files
-      let attachments = []
-      if (files.length) {
-        const fd = new FormData()
-        for (const f of files) fd.append('files', f)
-        const up = await fetch('/api/upload', { method: 'POST', body: fd, credentials: 'include' })
-        if (up.ok) attachments = (await up.json()).files
-      }
-      const payload = { ...this.entry, attachments }
-      await fetch('/api/entries', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify(payload)
-      })
-      this.entry = { date: '', shift: 'AM', line: '1', completedTasks: '', issues: '', nextActions: '' }
-      this.$refs.files.value = null
-      this.loadEntries()
-    },
-    async loadEntries() {
-      const params = new URLSearchParams()
-      if (this.filterDate) params.append('date', this.filterDate)
-      const res = await fetch('/api/entries?' + params.toString(), { credentials: 'include' })
-      if (res.ok) this.entries = await res.json()
-    }
-  }
-}
-</script>
 </body>
 </html>

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -1,5 +1,5 @@
 body {
-  background: linear-gradient(to bottom right, #e0f2fe, #fce7f3);
+  background-color: #f3f4f6; /* soft gray like MaintainX */
   font-family: 'Inter', sans-serif;
   min-height: 100vh;
 }
@@ -38,4 +38,22 @@ body {
 }
 .link:hover {
   text-decoration: underline;
+}
+
+/* top navigation styling */
+.header {
+  background-color: #1e40af; /* blue */
+  color: #ffffff;
+}
+
+.nav-btn {
+  color: #ffffff;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+}
+.nav-btn:hover {
+  background-color: #1e3a8a;
+}
+.nav-active {
+  background-color: #1e3a8a;
 }

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -1,0 +1,41 @@
+body {
+  background: linear-gradient(to bottom right, #e0f2fe, #fce7f3);
+  font-family: 'Inter', sans-serif;
+  min-height: 100vh;
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  color: #ffffff;
+}
+
+.btn-primary {
+  background-color: #2563eb;
+}
+.btn-primary:hover {
+  background-color: #1d4ed8;
+}
+
+.btn-secondary {
+  background-color: #16a34a;
+}
+.btn-secondary:hover {
+  background-color: #15803d;
+}
+
+.link {
+  color: #2563eb;
+  font-size: 0.875rem;
+}
+.link:hover {
+  text-decoration: underline;
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,7 +4,7 @@ import helmet from 'helmet'
 import cors from 'cors'
 import multer from 'multer'
 import { join } from 'path'
-import { existsSync, mkdirSync } from 'fs'
+import { existsSync, mkdirSync, writeFileSync } from 'fs'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
 import { initDb, db } from './db.js'
@@ -24,6 +24,11 @@ const uploadsDir = process.env.UPLOADS_DIR || join(process.cwd(), 'uploads')
 if (!existsSync(uploadsDir)) mkdirSync(uploadsDir, { recursive: true })
 const upload = multer({ dest: uploadsDir })
 app.use('/uploads', express.static(uploadsDir))
+
+// directory for exported entries
+const dataDir = process.env.DATA_DIR || join(process.cwd(), 'data')
+const entriesDir = join(dataDir, 'entries')
+if (!existsSync(entriesDir)) mkdirSync(entriesDir, { recursive: true })
 
 app.use(express.static(join(process.cwd(), 'public')))
 
@@ -48,6 +53,12 @@ function adminOnly(req, res, next) {
   next()
 }
 
+function saveEntryFile(entry) {
+  const fileName = `Motherlode_${entry.date}_Line${entry.line}.json`
+  const filePath = join(entriesDir, fileName)
+  writeFileSync(filePath, JSON.stringify(entry, null, 2))
+}
+
 // seed admin
 if (!db.data.users.find(u => u.email === 'admin@motherlode.local')) {
   const id = Date.now().toString()
@@ -65,7 +76,7 @@ app.post('/api/auth/login', async (req, res) => {
   const user = db.data.users.find(u => u.email === email)
   if (!user || !bcrypt.compareSync(password, user.password)) return res.status(401).json({ error: 'Invalid credentials' })
   const token = createToken(user)
-  res.cookie('token', token, { httpOnly: true, sameSite: 'lax' })
+  res.cookie('token', token, { httpOnly: true, sameSite: 'lax', secure: process.env.NODE_ENV === 'production' })
   res.json({ user: { id: user.id, name: user.name, role: user.role } })
 })
 
@@ -113,10 +124,15 @@ app.post('/api/upload', authRequired, upload.array('files'), (req, res) => {
 })
 
 app.post('/api/entries', authRequired, async (req, res) => {
-  const entry = { ...req.body, id: Date.now().toString(), createdBy: req.user.id, attachments: req.body.attachments || [] }
+  const { date, line, shift, completedTasks = '', issues = '', nextActions = '', attachments = [] } = req.body
   await db.read()
+  if (db.data.entries.find(e => e.date === date && e.line === line)) {
+    return res.status(400).json({ error: 'Entry already exists for this date and line' })
+  }
+  const entry = { id: Date.now().toString(), createdBy: req.user.id, date, line, shift, completedTasks, issues, nextActions, attachments }
   db.data.entries.push(entry)
   await db.write()
+  saveEntryFile(entry)
   res.status(201).json(entry)
 })
 
@@ -129,6 +145,17 @@ app.get('/api/entries', authRequired, async (req, res) => {
   if (line) entries = entries.filter(e => e.line === line)
   entries = entries.slice(-Number(limit)).reverse()
   res.json(entries)
+})
+
+app.get('/api/entries/export', authRequired, async (req, res) => {
+  const { date, line } = req.query
+  if (!date || !line) return res.status(400).json({ error: 'date and line required' })
+  await db.read()
+  const entry = db.data.entries.find(e => e.date === date && e.line === line)
+  if (!entry) return res.status(404).json({ error: 'Not found' })
+  const fileName = `Motherlode_${date}_Line${line}.json`
+  res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
+  res.send(JSON.stringify(entry, null, 2))
 })
 
 app.get('/api/entries/:id', authRequired, async (req, res) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,7 +7,7 @@ import { join } from 'path'
 import { existsSync, mkdirSync } from 'fs'
 import bcrypt from 'bcryptjs'
 import jwt from 'jsonwebtoken'
-import db from './db.js'
+import { initDb, db } from './db.js'
 
 const app = express()
 const PORT = process.env.PORT || 10000
@@ -26,6 +26,8 @@ const upload = multer({ dest: uploadsDir })
 app.use('/uploads', express.static(uploadsDir))
 
 app.use(express.static(join(process.cwd(), 'public')))
+
+await initDb()
 
 // helpers
 function createToken(user) {
@@ -47,7 +49,6 @@ function adminOnly(req, res, next) {
 }
 
 // seed admin
-await db.read()
 if (!db.data.users.find(u => u.email === 'admin@motherlode.local')) {
   const id = Date.now().toString()
   const password = bcrypt.hashSync('ChangeMe123!', 10)

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,159 @@
+import express from 'express'
+import cookieParser from 'cookie-parser'
+import helmet from 'helmet'
+import cors from 'cors'
+import multer from 'multer'
+import { join } from 'path'
+import { existsSync, mkdirSync } from 'fs'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+import db from './db.js'
+
+const app = express()
+const PORT = process.env.PORT || 10000
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret'
+const ORIGIN = process.env.ORIGIN || 'http://localhost:10000'
+
+app.use(helmet())
+app.use(express.json())
+app.use(cookieParser())
+app.use(cors({ origin: ORIGIN, credentials: true }))
+
+// file uploads
+const uploadsDir = process.env.UPLOADS_DIR || join(process.cwd(), 'uploads')
+if (!existsSync(uploadsDir)) mkdirSync(uploadsDir, { recursive: true })
+const upload = multer({ dest: uploadsDir })
+app.use('/uploads', express.static(uploadsDir))
+
+app.use(express.static(join(process.cwd(), 'public')))
+
+// helpers
+function createToken(user) {
+  return jwt.sign({ id: user.id, role: user.role }, JWT_SECRET, { expiresIn: '1d' })
+}
+function authRequired(req, res, next) {
+  const token = req.cookies.token
+  if (!token) return res.status(401).json({ error: 'Unauthorized' })
+  try {
+    req.user = jwt.verify(token, JWT_SECRET)
+    next()
+  } catch (e) {
+    return res.status(401).json({ error: 'Invalid token' })
+  }
+}
+function adminOnly(req, res, next) {
+  if (req.user.role !== 'admin') return res.status(403).json({ error: 'Forbidden' })
+  next()
+}
+
+// seed admin
+await db.read()
+if (!db.data.users.find(u => u.email === 'admin@motherlode.local')) {
+  const id = Date.now().toString()
+  const password = bcrypt.hashSync('ChangeMe123!', 10)
+  db.data.users.push({ id, name: 'Admin', email: 'admin@motherlode.local', password, role: 'admin' })
+  await db.write()
+}
+
+// routes
+app.get('/api/health', (req, res) => res.json({ ok: true }))
+
+app.post('/api/auth/login', async (req, res) => {
+  const { email, password } = req.body
+  await db.read()
+  const user = db.data.users.find(u => u.email === email)
+  if (!user || !bcrypt.compareSync(password, user.password)) return res.status(401).json({ error: 'Invalid credentials' })
+  const token = createToken(user)
+  res.cookie('token', token, { httpOnly: true, sameSite: 'lax' })
+  res.json({ user: { id: user.id, name: user.name, role: user.role } })
+})
+
+app.post('/api/auth/logout', (req, res) => {
+  res.clearCookie('token')
+  res.json({ ok: true })
+})
+
+app.get('/api/auth/me', authRequired, async (req, res) => {
+  await db.read()
+  const user = db.data.users.find(u => u.id === req.user.id)
+  res.json({ user: { id: user.id, name: user.name, role: user.role } })
+})
+
+app.post('/api/users', authRequired, adminOnly, async (req, res) => {
+  const { name, email, password, role } = req.body
+  await db.read()
+  if (db.data.users.find(u => u.email === email)) return res.status(400).json({ error: 'Email exists' })
+  const id = Date.now().toString()
+  const hash = bcrypt.hashSync(password, 10)
+  db.data.users.push({ id, name, email, password: hash, role })
+  await db.write()
+  res.status(201).json({ id, name, email, role })
+})
+
+app.get('/api/users', authRequired, adminOnly, async (req, res) => {
+  await db.read()
+  const users = db.data.users.map(u => ({ id: u.id, name: u.name, email: u.email, role: u.role }))
+  res.json(users)
+})
+
+app.post('/api/users/change-password', authRequired, async (req, res) => {
+  const { oldPassword, newPassword } = req.body
+  await db.read()
+  const user = db.data.users.find(u => u.id === req.user.id)
+  if (!bcrypt.compareSync(oldPassword, user.password)) return res.status(400).json({ error: 'Wrong password' })
+  user.password = bcrypt.hashSync(newPassword, 10)
+  await db.write()
+  res.json({ ok: true })
+})
+
+app.post('/api/upload', authRequired, upload.array('files'), (req, res) => {
+  const files = req.files.map(f => ({ filename: f.filename, originalname: f.originalname }))
+  res.json({ files })
+})
+
+app.post('/api/entries', authRequired, async (req, res) => {
+  const entry = { ...req.body, id: Date.now().toString(), createdBy: req.user.id, attachments: req.body.attachments || [] }
+  await db.read()
+  db.data.entries.push(entry)
+  await db.write()
+  res.status(201).json(entry)
+})
+
+app.get('/api/entries', authRequired, async (req, res) => {
+  const { date, shift, line, limit = 20 } = req.query
+  await db.read()
+  let entries = db.data.entries
+  if (date) entries = entries.filter(e => e.date === date)
+  if (shift) entries = entries.filter(e => e.shift === shift)
+  if (line) entries = entries.filter(e => e.line === line)
+  entries = entries.slice(-Number(limit)).reverse()
+  res.json(entries)
+})
+
+app.get('/api/entries/:id', authRequired, async (req, res) => {
+  await db.read()
+  const entry = db.data.entries.find(e => e.id === req.params.id)
+  if (!entry) return res.status(404).json({ error: 'Not found' })
+  res.json(entry)
+})
+
+app.put('/api/entries/:id', authRequired, async (req, res) => {
+  await db.read()
+  const entry = db.data.entries.find(e => e.id === req.params.id)
+  if (!entry) return res.status(404).json({ error: 'Not found' })
+  if (entry.createdBy !== req.user.id && req.user.role !== 'admin') return res.status(403).json({ error: 'Forbidden' })
+  Object.assign(entry, req.body)
+  await db.write()
+  res.json(entry)
+})
+
+app.delete('/api/entries/:id', authRequired, adminOnly, async (req, res) => {
+  await db.read()
+  const index = db.data.entries.findIndex(e => e.id === req.params.id)
+  if (index === -1) return res.status(404).json({ error: 'Not found' })
+  db.data.entries.splice(index, 1)
+  await db.write()
+  res.json({ ok: true })
+})
+
+app.listen(PORT, () => console.log(`Server running on ${PORT}`))

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,28 @@
+services:
+  - type: web
+    name: motherlode-passover
+    env: node
+    plan: free
+    region: oregon
+    rootDir: backend
+    runtime: node
+    nodeVersion: 22
+    autoDeploy: true
+    buildCommand: |
+      npm install
+    startCommand: |
+      node server.js
+    envVars:
+      - key: JWT_SECRET
+        generateValue: true
+      - key: ORIGIN
+        value: https://motherlode-passover.onrender.com
+      - key: DATA_DIR
+        value: /opt/render/project/src/backend/data
+      - key: UPLOADS_DIR
+        value: /opt/render/project/src/backend/uploads
+    disk:
+      name: persistent-data
+      mountPath: /opt/render/project/src/backend
+      sizeGB: 1
+    healthCheckPath: /api/health


### PR DESCRIPTION
## Summary
- implement Express backend with JWT auth, admin seeding, file uploads and lowdb persistence
- add single-page Tailwind/Alpine UI for login and creating pass-over entries
- configure Render deployment via `render.yaml`

## Testing
- `npm test`
- `node server.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_689a920d590c8324895b7f4f3e3e7e2d