### PR TITLE
Refine pass-over UI and entry handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+backend/node_modules
+backend/data
+backend/uploads

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# rmemeber
-remember
+# Motherlode Pass-Over App
+
+Simple shift pass-over web application using Node.js, Express, lowdb and a single-page HTML frontend.
+
+## Development
+
+```sh
+cd backend
+npm install
+node server.js
+```
+
+Default admin login: `admin@motherlode.local` / `ChangeMe123!`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Motherlode Pass-Over App
 
-Simple shift pass-over web application using Node.js, Express, lowdb and a single-page HTML frontend.
+Simple shift pass-over web application using Node.js, Express, lowdb and a small React frontend.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ node server.js
 ```
 
 Default admin login: `admin@motherlode.local` / `ChangeMe123!`
+
+The frontend uses TailwindCSS with a hero image and centered card layouts. If the login fails, an error message is shown.

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,38 @@
+import { Low } from 'lowdb'
+import { JSONFile } from 'lowdb/node'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// Where to store the DB file (override via env if you want)
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data')
+if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true })
+
+const file = path.join(DATA_DIR, 'motherlode.json')
+
+// *** IMPORTANT: provide default data ***
+const defaultData = {
+  users: [],
+  sessions: [],
+  entries: []
+}
+
+const adapter = new JSONFile(file)
+export const db = new Low(adapter, defaultData)
+
+export async function initDb() {
+  try {
+    await db.read()
+    // If file was empty or missing, ensure defaults are present
+    db.data ||= defaultData
+    await db.write()
+  } catch (err) {
+    console.error('Failed to init DB, resetting with defaults:', err)
+    db.data = defaultData
+    await db.write()
+  }
+}
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "motherlode-passover-backend",
+  "version": "1.0.0",
+  "description": "Shift Pass-Over Web App backend",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "helmet": "^7.0.0",
+    "jsonwebtoken": "^9.0.2",
+    "lowdb": "^6.0.1",
+    "multer": "^2.0.0-rc.1"
+  }
+}

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -8,8 +8,11 @@
   <script type="module" src="/main.js"></script>
   <title>Shift Pass-Over</title>
 </head>
-<body class="bg-gray-100 min-h-screen">
-  <header class="bg-sky-600 text-white p-4 text-center font-semibold">Motherlode Pass-Over</header>
-  <div id="root" class="p-4 max-w-4xl mx-auto"></div>
+<body class="bg-gray-100 min-h-screen flex flex-col items-center">
+  <header class="relative w-full">
+    <img src="https://images.unsplash.com/photo-1606761564823-1a95ca8d4319?auto=format&fit=crop&w=1600&q=80" alt="Factory" class="w-full h-48 object-cover">
+    <h1 class="hero-title">Motherlode Pass-Over</h1>
+  </header>
+  <div id="root" class="p-4 w-full max-w-4xl flex-1"></div>
 </body>
 </html>

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/style.css">
+  <script type="module" src="/main.js"></script>
+  <title>Shift Pass-Over</title>
+</head>
+<body class="bg-gray-100 min-h-screen">
+  <header class="bg-sky-600 text-white p-4 text-center font-semibold">Motherlode Pass-Over</header>
+  <main id="app" class="p-4 max-w-4xl mx-auto"></main>
+</body>
+</html>

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; img-src 'self' data: https://images.unsplash.com">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css">
   <script type="module" src="/main.js"></script>

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -10,6 +10,6 @@
 </head>
 <body class="bg-gray-100 min-h-screen">
   <header class="bg-sky-600 text-white p-4 text-center font-semibold">Motherlode Pass-Over</header>
-  <main id="app" class="p-4 max-w-4xl mx-auto"></main>
+  <div id="root" class="p-4 max-w-4xl mx-auto"></div>
 </body>
 </html>

--- a/backend/public/index.html
+++ b/backend/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; img-src 'self' data: https://images.unsplash.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdn.jsdelivr.net; img-src 'self' data: https://images.unsplash.com">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="/style.css">
   <script type="module" src="/main.js"></script>

--- a/backend/public/main.js
+++ b/backend/public/main.js
@@ -4,9 +4,11 @@ import ReactDOM from 'https://esm.sh/react-dom@18/client'
 function Login({ onLoggedIn }) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
 
   async function submit(e) {
     e.preventDefault()
+    setError('')
     const res = await fetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -16,13 +18,18 @@ function Login({ onLoggedIn }) {
     if (res.ok) {
       const { user } = await res.json()
       onLoggedIn(user)
+    } else {
+      const data = await res.json().catch(() => ({}))
+      setError(data.error || 'Login failed')
     }
   }
 
   return (
-    <form onSubmit={submit} className="card space-y-4 max-w-sm mx-auto mt-10">
-      <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" className="border p-2 w-full" required />
-      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2 w-full" required />
+    <form onSubmit={submit} className="card space-y-4 mt-10 text-center">
+      <img src="https://images.unsplash.com/photo-1581091012184-5c43e0d0b637?auto=format&fit=crop&w=600&q=80" alt="factory" className="w-full h-32 object-cover rounded" />
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+      <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="admin@motherlode.local" className="border p-2 w-full" required />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="ChangeMe123!" className="border p-2 w-full" required />
       <button className="btn btn-primary w-full">Login</button>
     </form>
   )
@@ -45,7 +52,7 @@ function ChangePassword() {
   }
 
   return (
-    <form onSubmit={submit} className="card space-y-2 max-w-sm">
+    <form onSubmit={submit} className="card space-y-2 max-w-sm mx-auto">
       <input type="password" value={oldPw} onChange={e => setOldPw(e.target.value)} placeholder="Old password" className="border p-2 w-full" required />
       <input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} placeholder="New password" className="border p-2 w-full" required />
       <button className="btn btn-primary">Update</button>
@@ -152,7 +159,7 @@ function Dashboard({ user, onLogout }) {
   const [showPw, setShowPw] = useState(false)
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 max-w-2xl mx-auto w-full">
       <div className="card flex justify-between items-center">
         <h2 className="text-lg font-semibold">Welcome {user.name}</h2>
         <div className="space-x-2">

--- a/backend/public/main.js
+++ b/backend/public/main.js
@@ -1,209 +1,190 @@
-const state = {
-  user: null,
-  entries: [],
-  filterDate: ''
-};
+import React, { useState, useEffect } from 'https://esm.sh/react@18'
+import ReactDOM from 'https://esm.sh/react-dom@18/client'
 
-async function init() {
-  const res = await fetch('/api/auth/me', { credentials: 'include' });
-  if (res.ok) {
-    state.user = (await res.json()).user;
-    renderDashboard();
-  } else {
-    renderLogin();
-  }
-}
+function Login({ onLoggedIn }) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
 
-document.addEventListener('DOMContentLoaded', init);
-
-function renderLogin() {
-  const app = document.getElementById('app');
-  app.innerHTML = '';
-  const form = document.createElement('form');
-  form.className = 'card space-y-4 max-w-sm mx-auto mt-10';
-  form.innerHTML = `
-    <input id="email" type="email" placeholder="Email" class="border p-2 w-full" required />
-    <input id="password" type="password" placeholder="Password" class="border p-2 w-full" required />
-    <button class="btn btn-primary w-full">Login</button>
-  `;
-  form.addEventListener('submit', async e => {
-    e.preventDefault();
-    const email = form.querySelector('#email').value;
-    const password = form.querySelector('#password').value;
+  async function submit(e) {
+    e.preventDefault()
     const res = await fetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ email, password })
-    });
+    })
     if (res.ok) {
-      state.user = (await res.json()).user;
-      renderDashboard();
+      const { user } = await res.json()
+      onLoggedIn(user)
     }
-  });
-  app.appendChild(form);
+  }
+
+  return (
+    <form onSubmit={submit} className="card space-y-4 max-w-sm mx-auto mt-10">
+      <input type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" className="border p-2 w-full" required />
+      <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2 w-full" required />
+      <button className="btn btn-primary w-full">Login</button>
+    </form>
+  )
 }
 
-function renderDashboard() {
-  const app = document.getElementById('app');
-  app.innerHTML = '';
-  const container = document.createElement('div');
-  container.className = 'space-y-6';
+function ChangePassword() {
+  const [oldPw, setOldPw] = useState('')
+  const [newPw, setNewPw] = useState('')
 
-  const top = document.createElement('div');
-  top.className = 'card flex justify-between items-center';
-  top.innerHTML = `
-    <h2 class="text-lg font-semibold">Welcome ${state.user.name}</h2>
-    <div class="space-x-2">
-      <button id="pwBtn" class="link">Change Password</button>
-      <button id="logoutBtn" class="link text-red-600">Logout</button>
-    </div>
-  `;
-  container.appendChild(top);
-
-  const pwForm = createPasswordForm();
-  pwForm.classList.add('hidden');
-  container.appendChild(pwForm);
-
-  const entryForm = createEntryForm();
-  container.appendChild(entryForm);
-
-  const listSection = createEntriesSection();
-  container.appendChild(listSection);
-
-  app.appendChild(container);
-
-  document.getElementById('logoutBtn').addEventListener('click', async () => {
-    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
-    state.user = null;
-    renderLogin();
-  });
-
-  document.getElementById('pwBtn').addEventListener('click', () => {
-    pwForm.classList.toggle('hidden');
-  });
-
-  loadEntries();
-}
-
-function createPasswordForm() {
-  const form = document.createElement('form');
-  form.className = 'card space-y-2 max-w-sm';
-  form.innerHTML = `
-    <input type="password" id="oldPw" placeholder="Old password" class="border p-2 w-full" required />
-    <input type="password" id="newPw" placeholder="New password" class="border p-2 w-full" required />
-    <button class="btn btn-primary">Update</button>
-  `;
-  form.addEventListener('submit', async e => {
-    e.preventDefault();
-    const oldPassword = form.querySelector('#oldPw').value;
-    const newPassword = form.querySelector('#newPw').value;
+  async function submit(e) {
+    e.preventDefault()
     await fetch('/api/users/change-password', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ oldPassword, newPassword })
-    });
-    form.reset();
-    form.classList.add('hidden');
-  });
-  return form;
+      body: JSON.stringify({ oldPassword: oldPw, newPassword: newPw })
+    })
+    setOldPw('')
+    setNewPw('')
+  }
+
+  return (
+    <form onSubmit={submit} className="card space-y-2 max-w-sm">
+      <input type="password" value={oldPw} onChange={e => setOldPw(e.target.value)} placeholder="Old password" className="border p-2 w-full" required />
+      <input type="password" value={newPw} onChange={e => setNewPw(e.target.value)} placeholder="New password" className="border p-2 w-full" required />
+      <button className="btn btn-primary">Update</button>
+    </form>
+  )
 }
 
-function createEntryForm() {
-  const form = document.createElement('form');
-  form.className = 'card space-y-3';
-  form.innerHTML = `
-    <h3 class="text-lg font-semibold">New Entry</h3>
-    <div class="flex flex-wrap gap-2">
-      <label>Date <input type="date" id="entryDate" required class="border p-1"></label>
-      <label>Shift
-        <select id="entryShift" class="border p-1" required>
-          <option value="AM">AM</option>
-          <option value="PM">PM</option>
-        </select>
-      </label>
-      <label>Line
-        <select id="entryLine" class="border p-1" required>
-          <option value="1">1</option>
-          <option value="2">2</option>
-        </select>
-      </label>
-    </div>
-    <textarea id="tasks" placeholder="Completed tasks" class="border w-full p-1"></textarea>
-    <textarea id="issues" placeholder="Issues" class="border w-full p-1"></textarea>
-    <textarea id="next" placeholder="Next actions" class="border w-full p-1"></textarea>
-    <input type="file" id="files" multiple />
-    <button class="btn btn-secondary">Save</button>
-  `;
-  form.addEventListener('submit', async e => {
-    e.preventDefault();
-    let attachments = [];
-    const files = form.querySelector('#files').files;
+function EntryForm({ onSaved }) {
+  const [date, setDate] = useState('')
+  const [shift, setShift] = useState('AM')
+  const [line, setLine] = useState('1')
+  const [tasks, setTasks] = useState('')
+  const [issues, setIssues] = useState('')
+  const [nextActions, setNextActions] = useState('')
+  const [files, setFiles] = useState([])
+
+  async function submit(e) {
+    e.preventDefault()
+    let attachments = []
     if (files.length) {
-      const fd = new FormData();
-      for (const f of files) fd.append('files', f);
-      const up = await fetch('/api/upload', { method: 'POST', body: fd, credentials: 'include' });
-      if (up.ok) attachments = (await up.json()).files;
+      const fd = new FormData()
+      for (const f of files) fd.append('files', f)
+      const up = await fetch('/api/upload', { method: 'POST', body: fd, credentials: 'include' })
+      if (up.ok) attachments = (await up.json()).files
     }
-    const payload = {
-      date: form.querySelector('#entryDate').value,
-      shift: form.querySelector('#entryShift').value,
-      line: form.querySelector('#entryLine').value,
-      completedTasks: form.querySelector('#tasks').value,
-      issues: form.querySelector('#issues').value,
-      nextActions: form.querySelector('#next').value,
-      attachments
-    };
     await fetch('/api/entries', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify(payload)
-    });
-    form.reset();
-    loadEntries();
-  });
-  return form;
-}
+      body: JSON.stringify({ date, shift, line, completedTasks: tasks, issues, nextActions, attachments })
+    })
+    setDate('')
+    setTasks('')
+    setIssues('')
+    setNextActions('')
+    setFiles([])
+    onSaved && onSaved()
+  }
 
-function createEntriesSection() {
-  const section = document.createElement('div');
-  section.className = 'card';
-  section.innerHTML = `
-    <div class="flex justify-between items-center mb-2">
-      <h3 class="text-lg font-semibold">Entries</h3>
-      <input type="date" id="filterDate" class="border p-1" />
-    </div>
-    <div id="entriesList"></div>
-  `;
-  section.querySelector('#filterDate').addEventListener('change', e => {
-    state.filterDate = e.target.value;
-    loadEntries();
-  });
-  return section;
-}
-
-async function loadEntries() {
-  const params = new URLSearchParams();
-  if (state.filterDate) params.append('date', state.filterDate);
-  const res = await fetch('/api/entries?' + params.toString(), { credentials: 'include' });
-  if (res.ok) state.entries = await res.json();
-  const list = document.getElementById('entriesList');
-  if (!list) return;
-  list.innerHTML = '';
-  state.entries.forEach(e => {
-    const item = document.createElement('div');
-    item.className = 'border p-2 my-2 rounded bg-white';
-    item.innerHTML = `
-      <div class="flex justify-between">
-        <div><b>${e.date}</b> - ${e.shift} - Line ${e.line}</div>
-        <a href="/api/entries/export?date=${e.date}&line=${e.line}" class="link">Export</a>
+  return (
+    <form onSubmit={submit} className="card space-y-3">
+      <h3 className="text-lg font-semibold">New Entry</h3>
+      <div className="flex flex-wrap gap-2">
+        <label>Date <input type="date" value={date} onChange={e => setDate(e.target.value)} required className="border p-1" /></label>
+        <label>Shift
+          <select value={shift} onChange={e => setShift(e.target.value)} className="border p-1" required>
+            <option value="AM">AM</option>
+            <option value="PM">PM</option>
+          </select>
+        </label>
+        <label>Line
+          <select value={line} onChange={e => setLine(e.target.value)} className="border p-1" required>
+            <option value="1">1</option>
+            <option value="2">2</option>
+          </select>
+        </label>
       </div>
-      <div class="mt-1">${e.completedTasks}</div>
-      <div class="mt-1">${e.issues}</div>
-      <div class="mt-1">${e.nextActions}</div>
-    `;
-    list.appendChild(item);
-  });
+      <textarea value={tasks} onChange={e => setTasks(e.target.value)} placeholder="Completed tasks" className="border w-full p-1" />
+      <textarea value={issues} onChange={e => setIssues(e.target.value)} placeholder="Issues" className="border w-full p-1" />
+      <textarea value={nextActions} onChange={e => setNextActions(e.target.value)} placeholder="Next actions" className="border w-full p-1" />
+      <input type="file" multiple onChange={e => setFiles(e.target.files)} />
+      <button className="btn btn-secondary">Save</button>
+    </form>
+  )
 }
+
+function EntriesList() {
+  const [entries, setEntries] = useState([])
+  const [filterDate, setFilterDate] = useState('')
+
+  async function load() {
+    const params = new URLSearchParams()
+    if (filterDate) params.append('date', filterDate)
+    const res = await fetch('/api/entries?' + params.toString(), { credentials: 'include' })
+    if (res.ok) setEntries(await res.json())
+  }
+
+  useEffect(() => { load() }, [filterDate])
+
+  return (
+    <div className="card">
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-lg font-semibold">Entries</h3>
+        <input type="date" value={filterDate} onChange={e => setFilterDate(e.target.value)} className="border p-1" />
+      </div>
+      <div>
+        {entries.map(e => (
+          <div key={e.id} className="border p-2 my-2 rounded bg-white">
+            <div className="flex justify-between">
+              <div><b>{e.date}</b> - {e.shift} - Line {e.line}</div>
+              <a className="link" href={`/api/entries/export?date=${e.date}&line=${e.line}`}>Export</a>
+            </div>
+            <div className="mt-1">{e.completedTasks}</div>
+            <div className="mt-1">{e.issues}</div>
+            <div className="mt-1">{e.nextActions}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Dashboard({ user, onLogout }) {
+  const [showPw, setShowPw] = useState(false)
+
+  return (
+    <div className="space-y-6">
+      <div className="card flex justify-between items-center">
+        <h2 className="text-lg font-semibold">Welcome {user.name}</h2>
+        <div className="space-x-2">
+          <button onClick={() => setShowPw(!showPw)} className="link">Change Password</button>
+          <button onClick={async () => { await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' }); onLogout() }} className="link text-red-600">Logout</button>
+        </div>
+      </div>
+      {showPw && <ChangePassword />}
+      <EntryForm onSaved={() => {}} />
+      <EntriesList />
+    </div>
+  )
+}
+
+function App() {
+  const [user, setUser] = useState(null)
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    fetch('/api/auth/me', { credentials: 'include' }).then(async res => {
+      if (res.ok) {
+        const data = await res.json()
+        setUser(data.user)
+      }
+      setLoaded(true)
+    })
+  }, [])
+
+  if (!loaded) return null
+  if (!user) return <Login onLoggedIn={setUser} />
+  return <Dashboard user={user} onLogout={() => setUser(null)} />
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />)
+

--- a/backend/public/main.js
+++ b/backend/public/main.js
@@ -1,0 +1,209 @@
+const state = {
+  user: null,
+  entries: [],
+  filterDate: ''
+};
+
+async function init() {
+  const res = await fetch('/api/auth/me', { credentials: 'include' });
+  if (res.ok) {
+    state.user = (await res.json()).user;
+    renderDashboard();
+  } else {
+    renderLogin();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);
+
+function renderLogin() {
+  const app = document.getElementById('app');
+  app.innerHTML = '';
+  const form = document.createElement('form');
+  form.className = 'card space-y-4 max-w-sm mx-auto mt-10';
+  form.innerHTML = `
+    <input id="email" type="email" placeholder="Email" class="border p-2 w-full" required />
+    <input id="password" type="password" placeholder="Password" class="border p-2 w-full" required />
+    <button class="btn btn-primary w-full">Login</button>
+  `;
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const email = form.querySelector('#email').value;
+    const password = form.querySelector('#password').value;
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ email, password })
+    });
+    if (res.ok) {
+      state.user = (await res.json()).user;
+      renderDashboard();
+    }
+  });
+  app.appendChild(form);
+}
+
+function renderDashboard() {
+  const app = document.getElementById('app');
+  app.innerHTML = '';
+  const container = document.createElement('div');
+  container.className = 'space-y-6';
+
+  const top = document.createElement('div');
+  top.className = 'card flex justify-between items-center';
+  top.innerHTML = `
+    <h2 class="text-lg font-semibold">Welcome ${state.user.name}</h2>
+    <div class="space-x-2">
+      <button id="pwBtn" class="link">Change Password</button>
+      <button id="logoutBtn" class="link text-red-600">Logout</button>
+    </div>
+  `;
+  container.appendChild(top);
+
+  const pwForm = createPasswordForm();
+  pwForm.classList.add('hidden');
+  container.appendChild(pwForm);
+
+  const entryForm = createEntryForm();
+  container.appendChild(entryForm);
+
+  const listSection = createEntriesSection();
+  container.appendChild(listSection);
+
+  app.appendChild(container);
+
+  document.getElementById('logoutBtn').addEventListener('click', async () => {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    state.user = null;
+    renderLogin();
+  });
+
+  document.getElementById('pwBtn').addEventListener('click', () => {
+    pwForm.classList.toggle('hidden');
+  });
+
+  loadEntries();
+}
+
+function createPasswordForm() {
+  const form = document.createElement('form');
+  form.className = 'card space-y-2 max-w-sm';
+  form.innerHTML = `
+    <input type="password" id="oldPw" placeholder="Old password" class="border p-2 w-full" required />
+    <input type="password" id="newPw" placeholder="New password" class="border p-2 w-full" required />
+    <button class="btn btn-primary">Update</button>
+  `;
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const oldPassword = form.querySelector('#oldPw').value;
+    const newPassword = form.querySelector('#newPw').value;
+    await fetch('/api/users/change-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ oldPassword, newPassword })
+    });
+    form.reset();
+    form.classList.add('hidden');
+  });
+  return form;
+}
+
+function createEntryForm() {
+  const form = document.createElement('form');
+  form.className = 'card space-y-3';
+  form.innerHTML = `
+    <h3 class="text-lg font-semibold">New Entry</h3>
+    <div class="flex flex-wrap gap-2">
+      <label>Date <input type="date" id="entryDate" required class="border p-1"></label>
+      <label>Shift
+        <select id="entryShift" class="border p-1" required>
+          <option value="AM">AM</option>
+          <option value="PM">PM</option>
+        </select>
+      </label>
+      <label>Line
+        <select id="entryLine" class="border p-1" required>
+          <option value="1">1</option>
+          <option value="2">2</option>
+        </select>
+      </label>
+    </div>
+    <textarea id="tasks" placeholder="Completed tasks" class="border w-full p-1"></textarea>
+    <textarea id="issues" placeholder="Issues" class="border w-full p-1"></textarea>
+    <textarea id="next" placeholder="Next actions" class="border w-full p-1"></textarea>
+    <input type="file" id="files" multiple />
+    <button class="btn btn-secondary">Save</button>
+  `;
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    let attachments = [];
+    const files = form.querySelector('#files').files;
+    if (files.length) {
+      const fd = new FormData();
+      for (const f of files) fd.append('files', f);
+      const up = await fetch('/api/upload', { method: 'POST', body: fd, credentials: 'include' });
+      if (up.ok) attachments = (await up.json()).files;
+    }
+    const payload = {
+      date: form.querySelector('#entryDate').value,
+      shift: form.querySelector('#entryShift').value,
+      line: form.querySelector('#entryLine').value,
+      completedTasks: form.querySelector('#tasks').value,
+      issues: form.querySelector('#issues').value,
+      nextActions: form.querySelector('#next').value,
+      attachments
+    };
+    await fetch('/api/entries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload)
+    });
+    form.reset();
+    loadEntries();
+  });
+  return form;
+}
+
+function createEntriesSection() {
+  const section = document.createElement('div');
+  section.className = 'card';
+  section.innerHTML = `
+    <div class="flex justify-between items-center mb-2">
+      <h3 class="text-lg font-semibold">Entries</h3>
+      <input type="date" id="filterDate" class="border p-1" />
+    </div>
+    <div id="entriesList"></div>
+  `;
+  section.querySelector('#filterDate').addEventListener('change', e => {
+    state.filterDate = e.target.value;
+    loadEntries();
+  });
+  return section;
+}
+
+async function loadEntries() {
+  const params = new URLSearchParams();
+  if (state.filterDate) params.append('date', state.filterDate);
+  const res = await fetch('/api/entries?' + params.toString(), { credentials: 'include' });
+  if (res.ok) state.entries = await res.json();
+  const list = document.getElementById('entriesList');
+  if (!list) return;
+  list.innerHTML = '';
+  state.entries.forEach(e => {
+    const item = document.createElement('div');
+    item.className = 'border p-2 my-2 rounded bg-white';
+    item.innerHTML = `
+      <div class="flex justify-between">
+        <div><b>${e.date}</b> - ${e.shift} - Line ${e.line}</div>
+        <a href="/api/entries/export?date=${e.date}&line=${e.line}" class="link">Export</a>
+      </div>
+      <div class="mt-1">${e.completedTasks}</div>
+      <div class="mt-1">${e.issues}</div>
+      <div class="mt-1">${e.nextActions}</div>
+    `;
+    list.appendChild(item);
+  });
+}

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -2,6 +2,9 @@ body {
   background-color: #f3f4f6;
   font-family: 'Inter', sans-serif;
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .card {
@@ -9,6 +12,9 @@ body {
   border-radius: 0.5rem;
   padding: 1.5rem;
   box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
+  max-width: 32rem;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .btn {
@@ -16,6 +22,7 @@ body {
   padding: 0.5rem 1rem;
   border-radius: 0.25rem;
   color: #ffffff;
+  cursor: pointer;
 }
 
 .btn-primary {
@@ -38,4 +45,16 @@ body {
 }
 .link:hover {
   text-decoration: underline;
+}
+
+.hero-title {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  color: #ffffff;
+  font-weight: 600;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.6);
 }

--- a/backend/public/style.css
+++ b/backend/public/style.css
@@ -1,0 +1,41 @@
+body {
+  background-color: #f3f4f6;
+  font-family: 'Inter', sans-serif;
+  min-height: 100vh;
+}
+
+.card {
+  background-color: #ffffff;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border-radius: 0.25rem;
+  color: #ffffff;
+}
+
+.btn-primary {
+  background-color: #0ea5e9;
+}
+.btn-primary:hover {
+  background-color: #0284c7;
+}
+
+.btn-secondary {
+  background-color: #16a34a;
+}
+.btn-secondary:hover {
+  background-color: #15803d;
+}
+
+.link {
+  color: #0ea5e9;
+  font-size: 0.875rem;
+}
+.link:hover {
+  text-decoration: underline;
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -24,12 +24,18 @@ app.use(
           'https://cdn.tailwindcss.com',
           'https://cdn.jsdelivr.net'
         ],
-        styleSrc: [
+        scriptSrcElem: [
           "'self'",
           'https://cdn.tailwindcss.com',
           'https://cdn.jsdelivr.net'
         ],
-        imgSrc: ["'self'", 'data:']
+        styleSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          'https://cdn.tailwindcss.com',
+          'https://cdn.jsdelivr.net'
+        ],
+        imgSrc: ["'self'", 'data:', 'https://images.unsplash.com']
       }
     }
   })

--- a/backend/server.js
+++ b/backend/server.js
@@ -14,7 +14,26 @@ const PORT = process.env.PORT || 10000
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret'
 const ORIGIN = process.env.ORIGIN || 'http://localhost:10000'
 
-app.use(helmet())
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: [
+          "'self'",
+          'https://cdn.tailwindcss.com',
+          'https://cdn.jsdelivr.net'
+        ],
+        styleSrc: [
+          "'self'",
+          'https://cdn.tailwindcss.com',
+          'https://cdn.jsdelivr.net'
+        ],
+        imgSrc: ["'self'", 'data:']
+      }
+    }
+  })
+)
 app.use(express.json())
 app.use(cookieParser())
 app.use(cors({ origin: ORIGIN, credentials: true }))

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,187 @@
+import express from 'express'
+import cookieParser from 'cookie-parser'
+import helmet from 'helmet'
+import cors from 'cors'
+import multer from 'multer'
+import { join } from 'path'
+import { existsSync, mkdirSync, writeFileSync } from 'fs'
+import bcrypt from 'bcryptjs'
+import jwt from 'jsonwebtoken'
+import { initDb, db } from './db.js'
+
+const app = express()
+const PORT = process.env.PORT || 10000
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret'
+const ORIGIN = process.env.ORIGIN || 'http://localhost:10000'
+
+app.use(helmet())
+app.use(express.json())
+app.use(cookieParser())
+app.use(cors({ origin: ORIGIN, credentials: true }))
+
+// file uploads
+const uploadsDir = process.env.UPLOADS_DIR || join(process.cwd(), 'uploads')
+if (!existsSync(uploadsDir)) mkdirSync(uploadsDir, { recursive: true })
+const upload = multer({ dest: uploadsDir })
+app.use('/uploads', express.static(uploadsDir))
+
+// directory for exported entries
+const dataDir = process.env.DATA_DIR || join(process.cwd(), 'data')
+const entriesDir = join(dataDir, 'entries')
+if (!existsSync(entriesDir)) mkdirSync(entriesDir, { recursive: true })
+
+app.use(express.static(join(process.cwd(), 'public')))
+
+await initDb()
+
+// helpers
+function createToken(user) {
+  return jwt.sign({ id: user.id, role: user.role }, JWT_SECRET, { expiresIn: '1d' })
+}
+function authRequired(req, res, next) {
+  const token = req.cookies.token
+  if (!token) return res.status(401).json({ error: 'Unauthorized' })
+  try {
+    req.user = jwt.verify(token, JWT_SECRET)
+    next()
+  } catch (e) {
+    return res.status(401).json({ error: 'Invalid token' })
+  }
+}
+function adminOnly(req, res, next) {
+  if (req.user.role !== 'admin') return res.status(403).json({ error: 'Forbidden' })
+  next()
+}
+
+function saveEntryFile(entry) {
+  const fileName = `Motherlode_${entry.date}_Line${entry.line}.json`
+  const filePath = join(entriesDir, fileName)
+  writeFileSync(filePath, JSON.stringify(entry, null, 2))
+}
+
+// seed admin
+if (!db.data.users.find(u => u.email === 'admin@motherlode.local')) {
+  const id = Date.now().toString()
+  const password = bcrypt.hashSync('ChangeMe123!', 10)
+  db.data.users.push({ id, name: 'Admin', email: 'admin@motherlode.local', password, role: 'admin' })
+  await db.write()
+}
+
+// routes
+app.get('/api/health', (req, res) => res.json({ ok: true }))
+
+app.post('/api/auth/login', async (req, res) => {
+  const { email, password } = req.body
+  await db.read()
+  const user = db.data.users.find(u => u.email === email)
+  if (!user || !bcrypt.compareSync(password, user.password)) return res.status(401).json({ error: 'Invalid credentials' })
+  const token = createToken(user)
+  res.cookie('token', token, { httpOnly: true, sameSite: 'lax', secure: process.env.NODE_ENV === 'production' })
+  res.json({ user: { id: user.id, name: user.name, role: user.role } })
+})
+
+app.post('/api/auth/logout', (req, res) => {
+  res.clearCookie('token')
+  res.json({ ok: true })
+})
+
+app.get('/api/auth/me', authRequired, async (req, res) => {
+  await db.read()
+  const user = db.data.users.find(u => u.id === req.user.id)
+  res.json({ user: { id: user.id, name: user.name, role: user.role } })
+})
+
+app.post('/api/users', authRequired, adminOnly, async (req, res) => {
+  const { name, email, password, role } = req.body
+  await db.read()
+  if (db.data.users.find(u => u.email === email)) return res.status(400).json({ error: 'Email exists' })
+  const id = Date.now().toString()
+  const hash = bcrypt.hashSync(password, 10)
+  db.data.users.push({ id, name, email, password: hash, role })
+  await db.write()
+  res.status(201).json({ id, name, email, role })
+})
+
+app.get('/api/users', authRequired, adminOnly, async (req, res) => {
+  await db.read()
+  const users = db.data.users.map(u => ({ id: u.id, name: u.name, email: u.email, role: u.role }))
+  res.json(users)
+})
+
+app.post('/api/users/change-password', authRequired, async (req, res) => {
+  const { oldPassword, newPassword } = req.body
+  await db.read()
+  const user = db.data.users.find(u => u.id === req.user.id)
+  if (!bcrypt.compareSync(oldPassword, user.password)) return res.status(400).json({ error: 'Wrong password' })
+  user.password = bcrypt.hashSync(newPassword, 10)
+  await db.write()
+  res.json({ ok: true })
+})
+
+app.post('/api/upload', authRequired, upload.array('files'), (req, res) => {
+  const files = req.files.map(f => ({ filename: f.filename, originalname: f.originalname }))
+  res.json({ files })
+})
+
+app.post('/api/entries', authRequired, async (req, res) => {
+  const { date, line, shift, completedTasks = '', issues = '', nextActions = '', attachments = [] } = req.body
+  await db.read()
+  if (db.data.entries.find(e => e.date === date && e.line === line)) {
+    return res.status(400).json({ error: 'Entry already exists for this date and line' })
+  }
+  const entry = { id: Date.now().toString(), createdBy: req.user.id, date, line, shift, completedTasks, issues, nextActions, attachments }
+  db.data.entries.push(entry)
+  await db.write()
+  saveEntryFile(entry)
+  res.status(201).json(entry)
+})
+
+app.get('/api/entries', authRequired, async (req, res) => {
+  const { date, shift, line, limit = 20 } = req.query
+  await db.read()
+  let entries = db.data.entries
+  if (date) entries = entries.filter(e => e.date === date)
+  if (shift) entries = entries.filter(e => e.shift === shift)
+  if (line) entries = entries.filter(e => e.line === line)
+  entries = entries.slice(-Number(limit)).reverse()
+  res.json(entries)
+})
+
+app.get('/api/entries/export', authRequired, async (req, res) => {
+  const { date, line } = req.query
+  if (!date || !line) return res.status(400).json({ error: 'date and line required' })
+  await db.read()
+  const entry = db.data.entries.find(e => e.date === date && e.line === line)
+  if (!entry) return res.status(404).json({ error: 'Not found' })
+  const fileName = `Motherlode_${date}_Line${line}.json`
+  res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`)
+  res.send(JSON.stringify(entry, null, 2))
+})
+
+app.get('/api/entries/:id', authRequired, async (req, res) => {
+  await db.read()
+  const entry = db.data.entries.find(e => e.id === req.params.id)
+  if (!entry) return res.status(404).json({ error: 'Not found' })
+  res.json(entry)
+})
+
+app.put('/api/entries/:id', authRequired, async (req, res) => {
+  await db.read()
+  const entry = db.data.entries.find(e => e.id === req.params.id)
+  if (!entry) return res.status(404).json({ error: 'Not found' })
+  if (entry.createdBy !== req.user.id && req.user.role !== 'admin') return res.status(403).json({ error: 'Forbidden' })
+  Object.assign(entry, req.body)
+  await db.write()
+  res.json(entry)
+})
+
+app.delete('/api/entries/:id', authRequired, adminOnly, async (req, res) => {
+  await db.read()
+  const index = db.data.entries.findIndex(e => e.id === req.params.id)
+  if (index === -1) return res.status(404).json({ error: 'Not found' })
+  db.data.entries.splice(index, 1)
+  await db.write()
+  res.json({ ok: true })
+})
+
+app.listen(PORT, () => console.log(`Server running on ${PORT}`))

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,28 @@
+services:
+  - type: web
+    name: motherlode-passover
+    env: node
+    plan: free
+    region: oregon
+    rootDir: backend
+    runtime: node
+    nodeVersion: 22
+    autoDeploy: true
+    buildCommand: |
+      npm install
+    startCommand: |
+      node server.js
+    envVars:
+      - key: JWT_SECRET
+        generateValue: true
+      - key: ORIGIN
+        value: https://motherlode-passover.onrender.com
+      - key: DATA_DIR
+        value: /opt/render/project/src/backend/data
+      - key: UPLOADS_DIR
+        value: /opt/render/project/src/backend/uploads
+    disk:
+      name: persistent-data
+      mountPath: /opt/render/project/src/backend
+      sizeGB: 1
+    healthCheckPath: /api/health


### PR DESCRIPTION
## Summary
- Rebuilt the frontend to render login, password, and entry forms entirely in JavaScript for a cleaner MaintainX-style experience
- Simplified HTML shell and refreshed styling for a modern blue/gray theme

## Testing
- `npm install` *(fails: 403 Forbidden - bcryptjs)*
- `npm test`
- `node server.js` *(fails: Cannot find package 'express')*


------
https://chatgpt.com/codex/tasks/task_e_689a920d590c8324895b7f4f3e3e7e2d